### PR TITLE
Fix typo in Hungarian translation for 'moderate' status

### DIFF
--- a/i18n/hu.yaml
+++ b/i18n/hu.yaml
@@ -143,7 +143,7 @@ air_quality:
     status: JÓ
     action: Nincs szükség intézkedésre
   moderate:
-    status: MÉRSEKELT
+    status: MÉRSÉKELT
     action: Ellenőrizd az értékeket
   poor:
     status: ROSSZ


### PR DESCRIPTION
Hi!
I noticed a small typo in the Hungarian translation (hu.yaml, line 146). I corrected "MÉRSEKELT" to "MÉRSÉKELT".