### PR TITLE
Replace airplanes.live with local ADS-B feeder for flight radar

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ AirDot can show local time and outdoor weather on a dedicated display page. Weat
 
 **Flight Radar**
 
-AirDot can show nearby aircraft on a minimal radar-style page when Wi-Fi and location are configured. Standard aircraft follow the selected display theme, while military or priority traffic is highlighted in orange.
+AirDot can show nearby aircraft on a minimal radar-style page when Wi-Fi and location are configured. Aircraft data comes from your own local ADS-B feeder (tar1090, readsb, or dump1090-fa) — enter its address (for example `192.168.1.50` or `adsb.local/tar1090`) in setup. Standard aircraft follow the selected display theme, while military or priority traffic is highlighted in orange.
 
 **Audio and display alerts**
 

--- a/i18n/cs.yaml
+++ b/i18n/cs.yaml
@@ -95,9 +95,11 @@ setup_page:
   location_longitude_label: Zeměpisná délka
 
   flight_radar_title: Letecký radar
-  flight_radar_note: Nastavte dosah a zobrazovaný provoz.
+  flight_radar_note: Používá váš místní ADS-B přijímač (tar1090, readsb nebo dump1090-fa). Nastavte dosah a zobrazovaný provoz.
   flight_radar_enabled_title: Letecký radar
   flight_radar_enabled_description: Zobrazovat živý letecký provoz na obrazovce radaru.
+  flight_radar_feeder_label: Adresa přijímače
+  flight_radar_feeder_placeholder: 192.168.1.50 nebo adsb.local/tar1090
   flight_radar_range_label: Dosah
   flight_radar_traffic_label: Provoz
   flight_radar_traffic_all_label: Všechna letadla

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -95,9 +95,11 @@ setup_page:
   location_longitude_label: Längengrad
 
   flight_radar_title: Flugradar
-  flight_radar_note: Lege Reichweite und sichtbaren Verkehr fest.
+  flight_radar_note: Nutzt deinen lokalen ADS-B-Empfänger (tar1090, readsb oder dump1090-fa). Lege Reichweite und sichtbaren Verkehr fest.
   flight_radar_enabled_title: Flugradar
   flight_radar_enabled_description: Zeige Live-Flugverkehr auf dem Radarschirm.
+  flight_radar_feeder_label: Feeder-Adresse
+  flight_radar_feeder_placeholder: 192.168.1.50 oder adsb.local/tar1090
   flight_radar_range_label: Reichweite
   flight_radar_traffic_label: Verkehr
   flight_radar_traffic_all_label: Alle Flugzeuge

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -95,9 +95,11 @@ setup_page:
   location_longitude_label: Longitude
 
   flight_radar_title: Flight radar
-  flight_radar_note: Set range and visible traffic.
+  flight_radar_note: Uses your local ADS-B feeder (tar1090, readsb or dump1090-fa). Set range and visible traffic.
   flight_radar_enabled_title: Flight radar
   flight_radar_enabled_description: Show live aircraft traffic on the radar screen.
+  flight_radar_feeder_label: Feeder address
+  flight_radar_feeder_placeholder: 192.168.1.50 or adsb.local/tar1090
   flight_radar_range_label: Range
   flight_radar_traffic_label: Traffic
   flight_radar_traffic_all_label: All aircraft

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -95,9 +95,11 @@ setup_page:
   location_longitude_label: Longitude
 
   flight_radar_title: Radar de vol
-  flight_radar_note: Définissez la portée et le trafic visible.
+  flight_radar_note: Utilise votre récepteur ADS-B local (tar1090, readsb ou dump1090-fa). Définissez la portée et le trafic visible.
   flight_radar_enabled_title: Radar de vol
   flight_radar_enabled_description: Affichez le trafic aérien en direct sur l'écran radar.
+  flight_radar_feeder_label: Adresse du récepteur
+  flight_radar_feeder_placeholder: 192.168.1.50 ou adsb.local/tar1090
   flight_radar_range_label: Portée
   flight_radar_traffic_label: Trafic
   flight_radar_traffic_all_label: Tous les avions

--- a/i18n/hu.yaml
+++ b/i18n/hu.yaml
@@ -95,9 +95,11 @@ setup_page:
   location_longitude_label: Hosszúság (Longitude)
 
   flight_radar_title: Repülőgép-radar
-  flight_radar_note: Hatótávolság és a megjelenített forgalom beállítása.
+  flight_radar_note: Helyi ADS-B vevőt használ (tar1090, readsb vagy dump1090-fa). Hatótávolság és a megjelenített forgalom beállítása.
   flight_radar_enabled_title: Repülőgép-radar
   flight_radar_enabled_description: Élő repülőgép-forgalom megjelenítése a radarképernyőn.
+  flight_radar_feeder_label: Vevő címe
+  flight_radar_feeder_placeholder: 192.168.1.50 vagy adsb.local/tar1090
   flight_radar_range_label: Hatótávolság
   flight_radar_traffic_label: Forgalom
   flight_radar_traffic_all_label: Összes repülőgép

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -95,9 +95,11 @@ setup_page:
   location_longitude_label: Longitudine
 
   flight_radar_title: Radar aereo
-  flight_radar_note: Imposta portata e traffico visibile.
+  flight_radar_note: Utilizza il tuo ricevitore ADS-B locale (tar1090, readsb o dump1090-fa). Imposta portata e traffico visibile.
   flight_radar_enabled_title: Radar aereo
   flight_radar_enabled_description: Mostra il traffico aereo in tempo reale nella schermata radar.
+  flight_radar_feeder_label: Indirizzo del ricevitore
+  flight_radar_feeder_placeholder: 192.168.1.50 o adsb.local/tar1090
   flight_radar_range_label: Portata
   flight_radar_traffic_label: Traffico
   flight_radar_traffic_all_label: Tutti gli aeromobili

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -95,9 +95,11 @@ setup_page:
   location_longitude_label: Lengtegraad
 
   flight_radar_title: Vluchtradar
-  flight_radar_note: Stel bereik en zichtbaar verkeer in.
+  flight_radar_note: Gebruikt je lokale ADS-B-ontvanger (tar1090, readsb of dump1090-fa). Stel bereik en zichtbaar verkeer in.
   flight_radar_enabled_title: Vluchtradar
   flight_radar_enabled_description: Toon live vliegtuigverkeer op het radarscherm.
+  flight_radar_feeder_label: Adres van de ontvanger
+  flight_radar_feeder_placeholder: 192.168.1.50 of adsb.local/tar1090
   flight_radar_range_label: Bereik
   flight_radar_traffic_label: Verkeer
   flight_radar_traffic_all_label: Alle vliegtuigen

--- a/i18n/ro.yaml
+++ b/i18n/ro.yaml
@@ -95,9 +95,11 @@ setup_page:
   location_longitude_label: Longitudine
 
   flight_radar_title: Radar de zbor
-  flight_radar_note: Setează raza și traficul vizibil.
+  flight_radar_note: Folosește receptorul tău ADS-B local (tar1090, readsb sau dump1090-fa). Setează raza și traficul vizibil.
   flight_radar_enabled_title: Radar de zbor
   flight_radar_enabled_description: Afișează traficul aerian live pe ecranul radar.
+  flight_radar_feeder_label: Adresa receptorului
+  flight_radar_feeder_placeholder: 192.168.1.50 sau adsb.local/tar1090
   flight_radar_range_label: Rază
   flight_radar_traffic_label: Trafic
   flight_radar_traffic_all_label: Toate aeronavele

--- a/includes/airdot/generated/i18n_texts.h
+++ b/includes/airdot/generated/i18n_texts.h
@@ -1226,6 +1226,8 @@ struct SetupPageText {
   const char *flight_radar_note;
   const char *flight_radar_enabled_title;
   const char *flight_radar_enabled_description;
+  const char *flight_radar_feeder_label;
+  const char *flight_radar_feeder_placeholder;
   const char *flight_radar_range_label;
   const char *flight_radar_traffic_label;
   const char *flight_radar_traffic_all_label;
@@ -1452,9 +1454,11 @@ inline SetupPageText setup_page_text(AirDot::UiLanguage language) {
         "Latitude",
         "Longitude",
         "Flight radar",
-        "Set range and visible traffic.",
+        "Uses your local ADS-B feeder (tar1090, readsb or dump1090-fa). Set range and visible traffic.",
         "Flight radar",
         "Show live aircraft traffic on the radar screen.",
+        "Feeder address",
+        "192.168.1.50 or adsb.local/tar1090",
         "Range",
         "Traffic",
         "All aircraft",
@@ -1579,9 +1583,11 @@ inline SetupPageText setup_page_text(AirDot::UiLanguage language) {
         "Breitengrad",
         "Längengrad",
         "Flugradar",
-        "Lege Reichweite und sichtbaren Verkehr fest.",
+        "Nutzt deinen lokalen ADS-B-Empfänger (tar1090, readsb oder dump1090-fa). Lege Reichweite und sichtbaren Verkehr fest.",
         "Flugradar",
         "Zeige Live-Flugverkehr auf dem Radarschirm.",
+        "Feeder-Adresse",
+        "192.168.1.50 oder adsb.local/tar1090",
         "Reichweite",
         "Verkehr",
         "Alle Flugzeuge",
@@ -1706,9 +1712,11 @@ inline SetupPageText setup_page_text(AirDot::UiLanguage language) {
         "Breedtegraad",
         "Lengtegraad",
         "Vluchtradar",
-        "Stel bereik en zichtbaar verkeer in.",
+        "Gebruikt je lokale ADS-B-ontvanger (tar1090, readsb of dump1090-fa). Stel bereik en zichtbaar verkeer in.",
         "Vluchtradar",
         "Toon live vliegtuigverkeer op het radarscherm.",
+        "Adres van de ontvanger",
+        "192.168.1.50 of adsb.local/tar1090",
         "Bereik",
         "Verkeer",
         "Alle vliegtuigen",
@@ -1833,9 +1841,11 @@ inline SetupPageText setup_page_text(AirDot::UiLanguage language) {
         "Latitude",
         "Longitude",
         "Radar de vol",
-        "Définissez la portée et le trafic visible.",
+        "Utilise votre récepteur ADS-B local (tar1090, readsb ou dump1090-fa). Définissez la portée et le trafic visible.",
         "Radar de vol",
         "Affichez le trafic aérien en direct sur l'écran radar.",
+        "Adresse du récepteur",
+        "192.168.1.50 ou adsb.local/tar1090",
         "Portée",
         "Trafic",
         "Tous les avions",
@@ -1960,9 +1970,11 @@ inline SetupPageText setup_page_text(AirDot::UiLanguage language) {
         "Szélesség (Latitude)",
         "Hosszúság (Longitude)",
         "Repülőgép-radar",
-        "Hatótávolság és a megjelenített forgalom beállítása.",
+        "Helyi ADS-B vevőt használ (tar1090, readsb vagy dump1090-fa). Hatótávolság és a megjelenített forgalom beállítása.",
         "Repülőgép-radar",
         "Élő repülőgép-forgalom megjelenítése a radarképernyőn.",
+        "Vevő címe",
+        "192.168.1.50 vagy adsb.local/tar1090",
         "Hatótávolság",
         "Forgalom",
         "Összes repülőgép",
@@ -2087,9 +2099,11 @@ inline SetupPageText setup_page_text(AirDot::UiLanguage language) {
         "Zeměpisná šířka",
         "Zeměpisná délka",
         "Letecký radar",
-        "Nastavte dosah a zobrazovaný provoz.",
+        "Používá váš místní ADS-B přijímač (tar1090, readsb nebo dump1090-fa). Nastavte dosah a zobrazovaný provoz.",
         "Letecký radar",
         "Zobrazovat živý letecký provoz na obrazovce radaru.",
+        "Adresa přijímače",
+        "192.168.1.50 nebo adsb.local/tar1090",
         "Dosah",
         "Provoz",
         "Všechna letadla",
@@ -2214,9 +2228,11 @@ inline SetupPageText setup_page_text(AirDot::UiLanguage language) {
         "Latitudine",
         "Longitudine",
         "Radar aereo",
-        "Imposta portata e traffico visibile.",
+        "Utilizza il tuo ricevitore ADS-B locale (tar1090, readsb o dump1090-fa). Imposta portata e traffico visibile.",
         "Radar aereo",
         "Mostra il traffico aereo in tempo reale nella schermata radar.",
+        "Indirizzo del ricevitore",
+        "192.168.1.50 o adsb.local/tar1090",
         "Portata",
         "Traffico",
         "Tutti gli aeromobili",
@@ -2341,9 +2357,11 @@ inline SetupPageText setup_page_text(AirDot::UiLanguage language) {
         "Latitudine",
         "Longitudine",
         "Radar de zbor",
-        "Setează raza și traficul vizibil.",
+        "Folosește receptorul tău ADS-B local (tar1090, readsb sau dump1090-fa). Setează raza și traficul vizibil.",
         "Radar de zbor",
         "Afișează traficul aerian live pe ecranul radar.",
+        "Adresa receptorului",
+        "192.168.1.50 sau adsb.local/tar1090",
         "Rază",
         "Trafic",
         "Toate aeronavele",
@@ -2515,6 +2533,8 @@ inline void append_setup_page_translation_json(std::string &html, AirDot::UiLang
   append_json_field_(html, "flight_radar_note", text.flight_radar_note, first);
   append_json_field_(html, "flight_radar_enabled_title", text.flight_radar_enabled_title, first);
   append_json_field_(html, "flight_radar_enabled_description", text.flight_radar_enabled_description, first);
+  append_json_field_(html, "flight_radar_feeder_label", text.flight_radar_feeder_label, first);
+  append_json_field_(html, "flight_radar_feeder_placeholder", text.flight_radar_feeder_placeholder, first);
   append_json_field_(html, "flight_radar_range_label", text.flight_radar_range_label, first);
   append_json_field_(html, "flight_radar_traffic_label", text.flight_radar_traffic_label, first);
   append_json_field_(html, "flight_radar_traffic_all_label", text.flight_radar_traffic_all_label, first);

--- a/includes/airdot/network/flight_radar_client.h
+++ b/includes/airdot/network/flight_radar_client.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #ifdef USE_ESP32
-#include <esp_crt_bundle.h>
 #include <esp_err.h>
 #include <esp_heap_caps.h>
 #include <esp_http_client.h>
@@ -58,14 +57,16 @@ inline constexpr int FLIGHT_RADAR_TASK_SUCCESS = 2;
 inline constexpr int FLIGHT_RADAR_TASK_FAILED = 3;
 inline constexpr uint32_t FLIGHT_RADAR_HTTP_TASK_STACK_SIZE = 12288;
 inline constexpr int FLIGHT_RADAR_HTTP_TIMEOUT_MS = 3500;
-inline constexpr size_t FLIGHT_RADAR_MAX_RESPONSE_BYTES = 16384;
-inline constexpr uint16_t FLIGHT_RADAR_MAX_PARSED_AIRCRAFT_OBJECTS = 96;
+// The local feeder's aircraft.json contains every aircraft the receiver sees,
+// not just nearby traffic, so the buffer must hold a few hundred entries.
+inline constexpr size_t FLIGHT_RADAR_MAX_RESPONSE_BYTES = 262144;
+inline constexpr uint16_t FLIGHT_RADAR_MAX_PARSED_AIRCRAFT_OBJECTS = 1024;
+inline constexpr size_t FLIGHT_RADAR_FEEDER_ADDRESS_BUFFER = 128;
 inline constexpr uint8_t FLIGHT_RADAR_LOCATION_COORDS = 0;
 inline constexpr uint8_t FLIGHT_RADAR_LOCATION_IP = 1;
 inline constexpr float DEG_TO_RAD = 0.017453292519943295769f;
 inline constexpr float RAD_TO_DEG = 57.295779513082320876f;
 inline constexpr float EARTH_RADIUS_KM = 6371.0f;
-inline constexpr float KM_PER_NAUTICAL_MILE = 1.852f;
 
 inline bool coordinates_are_valid_(float latitude, float longitude) {
   return std::isfinite(latitude) && std::isfinite(longitude) &&
@@ -110,6 +111,13 @@ inline std::atomic<uint8_t> &request_range_km_() {
 inline std::atomic<uint8_t> &request_military_only_() {
   static std::atomic<uint8_t> military_only{0};
   return military_only;
+}
+
+// Written by the start functions only after winning the IDLE->RUNNING CAS, read
+// by the single worker task, so no extra locking is needed.
+inline char *request_feeder_address_() {
+  static char address[FLIGHT_RADAR_FEEDER_ADDRESS_BUFFER]{};
+  return address;
 }
 
 inline uint8_t normalize_request_range_km_(uint8_t range_km) {
@@ -511,28 +519,28 @@ inline void skip_json_value_if_needed_(const char *before, const char *&cursor, 
     skip_json_value_(cursor, end);
 }
 
-inline bool read_airplanes_live_number_(const char *&cursor, const char *end, float &value) {
+inline bool read_feeder_number_(const char *&cursor, const char *end, float &value) {
   const char *before = cursor;
   const bool parsed = parse_json_number_(cursor, end, value);
   skip_json_value_if_needed_(before, cursor, end);
   return parsed;
 }
 
-inline bool read_airplanes_live_uint_(const char *&cursor, const char *end, uint32_t &value) {
+inline bool read_feeder_uint_(const char *&cursor, const char *end, uint32_t &value) {
   const char *before = cursor;
   const bool parsed = parse_json_uint_(cursor, end, value);
   skip_json_value_if_needed_(before, cursor, end);
   return parsed;
 }
 
-inline bool read_airplanes_live_bool_(const char *&cursor, const char *end, bool &value) {
+inline bool read_feeder_bool_(const char *&cursor, const char *end, bool &value) {
   const char *before = cursor;
   const bool parsed = parse_json_bool_(cursor, end, value);
   skip_json_value_if_needed_(before, cursor, end);
   return parsed;
 }
 
-inline bool read_airplanes_live_ground_state_(const char *&cursor, const char *end, bool &on_ground) {
+inline bool read_feeder_ground_state_(const char *&cursor, const char *end, bool &on_ground) {
   skip_json_space_(cursor, end);
   if (cursor < end && *cursor == '"') {
     char text[16]{};
@@ -547,7 +555,7 @@ inline bool read_airplanes_live_ground_state_(const char *&cursor, const char *e
   return skip_json_value_(cursor, end);
 }
 
-inline bool parse_airplanes_live_aircraft_(const char *&cursor, const char *end, float own_latitude,
+inline bool parse_feeder_aircraft_(const char *&cursor, const char *end, float own_latitude,
                                            float own_longitude, float range_km, bool military_only,
                                            Snapshot &snapshot) {
   skip_json_space_(cursor, end);
@@ -590,25 +598,25 @@ inline bool parse_airplanes_live_aircraft_(const char *&cursor, const char *end,
       parse_json_string_(cursor, end, callsign, sizeof(callsign));
       skip_json_value_if_needed_(before, cursor, end);
     } else if (std::strcmp(key, "lat") == 0) {
-      read_airplanes_live_number_(cursor, end, latitude);
+      read_feeder_number_(cursor, end, latitude);
     } else if (std::strcmp(key, "lon") == 0) {
-      read_airplanes_live_number_(cursor, end, longitude);
+      read_feeder_number_(cursor, end, longitude);
     } else if (std::strcmp(key, "alt_baro") == 0) {
-      read_airplanes_live_ground_state_(cursor, end, on_ground);
+      read_feeder_ground_state_(cursor, end, on_ground);
     } else if (std::strcmp(key, "track") == 0) {
-      read_airplanes_live_number_(cursor, end, track_deg);
+      read_feeder_number_(cursor, end, track_deg);
     } else if (std::strcmp(key, "true_heading") == 0) {
-      read_airplanes_live_number_(cursor, end, true_heading_deg);
+      read_feeder_number_(cursor, end, true_heading_deg);
     } else if (std::strcmp(key, "mag_heading") == 0) {
-      read_airplanes_live_number_(cursor, end, magnetic_heading_deg);
+      read_feeder_number_(cursor, end, magnetic_heading_deg);
     } else if (std::strcmp(key, "dir") == 0) {
-      read_airplanes_live_number_(cursor, end, dir_deg);
+      read_feeder_number_(cursor, end, dir_deg);
     } else if (std::strcmp(key, "dbFlags") == 0) {
-      if (read_airplanes_live_uint_(cursor, end, db_flags))
+      if (read_feeder_uint_(cursor, end, db_flags))
         military = military || (db_flags & 1U) != 0;
     } else if (std::strcmp(key, "mil") == 0) {
       bool mil = false;
-      if (read_airplanes_live_bool_(cursor, end, mil))
+      if (read_feeder_bool_(cursor, end, mil))
         military = military || mil;
     } else {
       skip_json_value_(cursor, end);
@@ -654,7 +662,7 @@ inline bool parse_airplanes_live_aircraft_(const char *&cursor, const char *end,
   return true;
 }
 
-inline bool parse_airplanes_live_response_(const char *json, size_t json_length, float latitude, float longitude,
+inline bool parse_feeder_response_(const char *json, size_t json_length, float latitude, float longitude,
                                            uint8_t range_km, bool military_only, Snapshot &snapshot,
                                            bool allow_partial = false) {
   if (json == nullptr || json_length == 0)
@@ -669,10 +677,17 @@ inline bool parse_airplanes_live_response_(const char *json, size_t json_length,
   snapshot.range_km = normalize_request_range_km_(range_km);
   snapshot.received_ms = esphome::millis();
 
-  const char *aircraft_key = find_pattern_(begin, end, "\"ac\"");
+  // tar1090/readsb/dump1090-fa aircraft.json uses "aircraft"; readsb's re-api
+  // style responses use "ac". Accept both.
+  const char *aircraft_key = find_pattern_(begin, end, "\"aircraft\"");
+  size_t key_length = 10;
+  if (aircraft_key == nullptr) {
+    aircraft_key = find_pattern_(begin, end, "\"ac\"");
+    key_length = 4;
+  }
   if (aircraft_key == nullptr)
     return false;
-  const char *colon = find_char_(aircraft_key + 4, end, ':');
+  const char *colon = find_char_(aircraft_key + key_length, end, ':');
   if (colon == nullptr)
     return false;
 
@@ -690,7 +705,7 @@ inline bool parse_airplanes_live_response_(const char *json, size_t json_length,
     if (cursor < end && *cursor == ']')
       break;
     if (cursor < end && *cursor == '{') {
-      if (!parse_airplanes_live_aircraft_(
+      if (!parse_feeder_aircraft_(
               cursor, end, latitude, longitude, static_cast<float>(snapshot.range_km), military_only, snapshot)) {
         if (allow_partial)
           break;
@@ -715,8 +730,16 @@ inline bool parse_airplanes_live_response_(const char *json, size_t json_length,
   return true;
 }
 
-inline bool fetch_airplanes_live_aircraft_(float latitude, float longitude, uint8_t range_km,
-                                           bool military_only, Snapshot &snapshot) {
+inline bool fetch_feeder_aircraft_(const char *feeder_address, float latitude, float longitude,
+                                   uint8_t range_km, bool military_only, Snapshot &snapshot) {
+  if (feeder_address == nullptr || feeder_address[0] == '\0') {
+    AirDot::connectivity::set_service_status(
+        AirDot::connectivity::Service::FLIGHT_RADAR,
+        AirDot::connectivity::ConnectivityStatus::CONFIG_INVALID,
+        AirDot::connectivity::ConnectivityError::CONFIG_MISSING, esphome::millis());
+    return false;
+  }
+
   if (!coordinates_are_valid_(latitude, longitude)) {
     AirDot::connectivity::set_service_status(
         AirDot::connectivity::Service::FLIGHT_RADAR,
@@ -726,13 +749,10 @@ inline bool fetch_airplanes_live_aircraft_(float latitude, float longitude, uint
   }
 
   const uint8_t normalized_range_km = normalize_request_range_km_(range_km);
-  const float distance_nm = static_cast<float>(normalized_range_km) / KM_PER_NAUTICAL_MILE;
 
   char url[384];
   const int written = std::snprintf(
-      url, sizeof(url),
-      "https://api.airplanes.live/v2/point/%.6f/%.6f/%.1f",
-      latitude, longitude, distance_nm);
+      url, sizeof(url), "http://%s/data/aircraft.json", feeder_address);
   if (written <= 0 || static_cast<size_t>(written) >= sizeof(url)) {
     note_flight_radar_failure_(AirDot::connectivity::ConnectivityError::CONFIG_INVALID);
     return false;
@@ -760,9 +780,6 @@ inline bool fetch_airplanes_live_aircraft_(float latitude, float longitude, uint
   config.buffer_size_tx = 256;
   config.user_agent = "";
   config.addr_type = HTTP_ADDR_TYPE_INET;
-#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
-  config.crt_bundle_attach = esp_crt_bundle_attach;
-#endif
 
   esp_http_client_handle_t client = esp_http_client_init(&config);
   if (client == nullptr) {
@@ -780,7 +797,7 @@ inline bool fetch_airplanes_live_aircraft_(float latitude, float longitude, uint
   }
 
   Snapshot parsed{};
-  if (!parse_airplanes_live_response_(response.body, response.length, latitude, longitude,
+  if (!parse_feeder_response_(response.body, response.length, latitude, longitude,
                                       normalized_range_km, military_only, parsed, response.overflow)) {
     note_flight_radar_failure_(AirDot::connectivity::ConnectivityError::INVALID_RESPONSE);
     return false;
@@ -789,6 +806,21 @@ inline bool fetch_airplanes_live_aircraft_(float latitude, float longitude, uint
   snapshot = parsed;
   note_flight_radar_success_();
   return true;
+}
+
+inline std::atomic<int32_t> &cached_ip_latitude_e7_() {
+  static std::atomic<int32_t> latitude{0};
+  return latitude;
+}
+
+inline std::atomic<int32_t> &cached_ip_longitude_e7_() {
+  static std::atomic<int32_t> longitude{0};
+  return longitude;
+}
+
+inline std::atomic<uint8_t> &cached_ip_location_valid_() {
+  static std::atomic<uint8_t> valid{0};
+  return valid;
 }
 
 inline void flight_radar_task_(void *) {
@@ -806,19 +838,30 @@ inline void flight_radar_task_(void *) {
   bool location_available = true;
   const uint8_t location_mode = request_location_mode_().load(std::memory_order_acquire);
   if (acquired && location_mode == FLIGHT_RADAR_LOCATION_IP) {
-    location_available = AirDot::time_weather::fetch_ipwhois_location(latitude, longitude);
-    if (!location_available) {
-      const auto status = AirDot::connectivity::get_service_status(
-          AirDot::connectivity::Service::WEATHER_LOCATION);
-      note_flight_radar_failure_(
-          status.error == AirDot::connectivity::ConnectivityError::NONE
-              ? AirDot::connectivity::ConnectivityError::INVALID_RESPONSE
-              : status.error);
+    // The device does not move; resolve the IP-based location once and reuse it
+    // instead of asking ipwho.is again on every poll.
+    if (cached_ip_location_valid_().load(std::memory_order_acquire) == 1) {
+      latitude = static_cast<float>(cached_ip_latitude_e7_().load(std::memory_order_acquire)) / 10000000.0f;
+      longitude = static_cast<float>(cached_ip_longitude_e7_().load(std::memory_order_acquire)) / 10000000.0f;
+    } else {
+      location_available = AirDot::time_weather::fetch_ipwhois_location(latitude, longitude);
+      if (location_available) {
+        cached_ip_latitude_e7_().store(static_cast<int32_t>(latitude * 10000000.0f), std::memory_order_release);
+        cached_ip_longitude_e7_().store(static_cast<int32_t>(longitude * 10000000.0f), std::memory_order_release);
+        cached_ip_location_valid_().store(1, std::memory_order_release);
+      } else {
+        const auto status = AirDot::connectivity::get_service_status(
+            AirDot::connectivity::Service::WEATHER_LOCATION);
+        note_flight_radar_failure_(
+            status.error == AirDot::connectivity::ConnectivityError::NONE
+                ? AirDot::connectivity::ConnectivityError::INVALID_RESPONSE
+                : status.error);
+      }
     }
   }
 
   if (acquired && location_available &&
-      fetch_airplanes_live_aircraft_(latitude, longitude, range_km, military_only, snapshot)) {
+      fetch_feeder_aircraft_(request_feeder_address_(), latitude, longitude, range_km, military_only, snapshot)) {
     SnapshotLock lock(20);
     if (lock.locked()) {
       current_snapshot_storage_() = snapshot;
@@ -836,8 +879,22 @@ inline void flight_radar_task_(void *) {
   vTaskDelete(nullptr);
 }
 
-inline bool start_airplanes_live_request(float latitude, float longitude, uint8_t range_km = FLIGHT_RADAR_RADIUS_DEFAULT_KM,
-                                         bool military_only = false) {
+inline bool feeder_address_usable_(const char *feeder_address) {
+  if (feeder_address != nullptr && feeder_address[0] != '\0')
+    return true;
+  AirDot::connectivity::set_service_status(
+      AirDot::connectivity::Service::FLIGHT_RADAR,
+      AirDot::connectivity::ConnectivityStatus::CONFIG_INVALID,
+      AirDot::connectivity::ConnectivityError::CONFIG_MISSING, esphome::millis());
+  return false;
+}
+
+inline bool start_flight_radar_request(const char *feeder_address, float latitude, float longitude,
+                                       uint8_t range_km = FLIGHT_RADAR_RADIUS_DEFAULT_KM,
+                                       bool military_only = false) {
+  if (!feeder_address_usable_(feeder_address))
+    return false;
+
   if (!coordinates_are_valid_(latitude, longitude)) {
     AirDot::connectivity::set_service_status(
         AirDot::connectivity::Service::FLIGHT_RADAR,
@@ -854,6 +911,7 @@ inline bool start_airplanes_live_request(float latitude, float longitude, uint8_
           expected, FLIGHT_RADAR_TASK_RUNNING, std::memory_order_acq_rel))
     return false;
 
+  std::snprintf(request_feeder_address_(), FLIGHT_RADAR_FEEDER_ADDRESS_BUFFER, "%s", feeder_address);
   request_latitude_e7_().store(static_cast<int32_t>(latitude * 10000000.0f), std::memory_order_release);
   request_longitude_e7_().store(static_cast<int32_t>(longitude * 10000000.0f), std::memory_order_release);
   request_location_mode_().store(FLIGHT_RADAR_LOCATION_COORDS, std::memory_order_release);
@@ -870,8 +928,12 @@ inline bool start_airplanes_live_request(float latitude, float longitude, uint8_
   return false;
 }
 
-inline bool start_airplanes_live_for_current_location_request(uint8_t range_km = FLIGHT_RADAR_RADIUS_DEFAULT_KM,
-                                                              bool military_only = false) {
+inline bool start_flight_radar_for_current_location_request(const char *feeder_address,
+                                                            uint8_t range_km = FLIGHT_RADAR_RADIUS_DEFAULT_KM,
+                                                            bool military_only = false) {
+  if (!feeder_address_usable_(feeder_address))
+    return false;
+
   if (!flight_radar_start_allowed_())
     return false;
 
@@ -880,6 +942,7 @@ inline bool start_airplanes_live_for_current_location_request(uint8_t range_km =
           expected, FLIGHT_RADAR_TASK_RUNNING, std::memory_order_acq_rel))
     return false;
 
+  std::snprintf(request_feeder_address_(), FLIGHT_RADAR_FEEDER_ADDRESS_BUFFER, "%s", feeder_address);
   request_latitude_e7_().store(0, std::memory_order_release);
   request_longitude_e7_().store(0, std::memory_order_release);
   request_location_mode_().store(FLIGHT_RADAR_LOCATION_IP, std::memory_order_release);
@@ -896,7 +959,7 @@ inline bool start_airplanes_live_for_current_location_request(uint8_t range_km =
   return false;
 }
 
-inline int consume_airplanes_live_result(Snapshot &snapshot) {
+inline int consume_flight_radar_result(Snapshot &snapshot) {
   const int state = flight_radar_task_state_().load(std::memory_order_acquire);
   if (state == FLIGHT_RADAR_TASK_SUCCESS) {
     {
@@ -920,22 +983,25 @@ inline int consume_airplanes_live_result(Snapshot &snapshot) {
 #else
 inline Snapshot current_snapshot() { return {}; }
 inline bool request_running() { return false; }
-inline bool start_airplanes_live_request(float latitude, float longitude,
-                                         uint8_t range_km = FLIGHT_RADAR_RADIUS_DEFAULT_KM,
-                                         bool military_only = false) {
+inline bool start_flight_radar_request(const char *feeder_address, float latitude, float longitude,
+                                       uint8_t range_km = FLIGHT_RADAR_RADIUS_DEFAULT_KM,
+                                       bool military_only = false) {
+  (void) feeder_address;
   (void) latitude;
   (void) longitude;
   (void) range_km;
   (void) military_only;
   return false;
 }
-inline bool start_airplanes_live_for_current_location_request(uint8_t range_km = FLIGHT_RADAR_RADIUS_DEFAULT_KM,
-                                                              bool military_only = false) {
+inline bool start_flight_radar_for_current_location_request(const char *feeder_address,
+                                                            uint8_t range_km = FLIGHT_RADAR_RADIUS_DEFAULT_KM,
+                                                            bool military_only = false) {
+  (void) feeder_address;
   (void) range_km;
   (void) military_only;
   return false;
 }
-inline int consume_airplanes_live_result(Snapshot &snapshot) {
+inline int consume_flight_radar_result(Snapshot &snapshot) {
   (void) snapshot;
   return -1;
 }

--- a/includes/airdot/setup/setup_page_renderer.h
+++ b/includes/airdot/setup/setup_page_renderer.h
@@ -156,6 +156,7 @@ class SetupPageRenderer {
         flight_radar_settings.traffic_mode == FLIGHT_RADAR_TRAFFIC_MILITARY_ONLY;
     const uint8_t flight_radar_range_km = normalize_flight_radar_range_km(flight_radar_settings.range_km);
     const std::string flight_radar_range_value = std::to_string(static_cast<unsigned>(flight_radar_range_km));
+    const std::string flight_radar_feeder_address = fixed_string_(flight_radar_settings.feeder_address);
     char mqtt_port_value[6];
     std::snprintf(
         mqtt_port_value, sizeof(mqtt_port_value), "%u", static_cast<unsigned>(mqtt_settings.port));
@@ -1700,6 +1701,20 @@ class SetupPageRenderer {
     html += R"html(">
                 <div class="field">
 )html";
+    html += "                  <label for=\"flight_radar_feeder_address\" data-i18n=\"flight_radar_feeder_label\">";
+    html += text.flight_radar_feeder_label;
+    html += "</label>\n                  <input id=\"flight_radar_feeder_address\" name=\"flight_radar_feeder_address\" type=\"text\" inputmode=\"url\" data-i18n-placeholder=\"flight_radar_feeder_placeholder\" placeholder=\"";
+    html += html_escape_(text.flight_radar_feeder_placeholder);
+    html += R"html(" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" enterkeyhint="next" maxlength="96" value=")html";
+    html += html_escape_(flight_radar_feeder_address);
+    html += "\"";
+    if (!flight_radar_active)
+      html += " disabled";
+    html += R"html(>
+                </div>
+
+                <div class="field">
+)html";
     html += "                  <label for=\"flight_radar_range_km\" data-i18n=\"flight_radar_range_label\">";
     html += text.flight_radar_range_label;
     html += R"html(</label>
@@ -2219,6 +2234,7 @@ class SetupPageRenderer {
             const flightRadarEnabledInput = document.getElementById("flight_radar_enabled");
             const flightRadarFields = document.getElementById("flight_radar_fields");
             const flightRadarRangeInput = document.getElementById("flight_radar_range_km");
+            const flightRadarFeederInput = document.getElementById("flight_radar_feeder_address");
             const flightRadarTrafficInputs = Array.from(document.querySelectorAll("input[name='flight_radar_traffic']"));
             const integrationsSection = document.getElementById("integrations_section");
             const integrationInterval = document.getElementById("integration_interval");
@@ -2461,6 +2477,7 @@ class SetupPageRenderer {
                 flightRadarFields.classList.toggle("is-disabled", !active);
               }
               if (flightRadarRangeInput) flightRadarRangeInput.disabled = !active;
+              if (flightRadarFeederInput) flightRadarFeederInput.disabled = !active;
               setDisabled(flightRadarTrafficInputs, !active);
               updateFlightRadarRangeLabels();
             }

--- a/includes/airdot/setup/setup_portal.h
+++ b/includes/airdot/setup/setup_portal.h
@@ -197,13 +197,18 @@ class SetupHandler : public AsyncWebHandler {
         request->hasArg("flight_radar_traffic")
             ? bounded_arg_(request, "flight_radar_traffic", 16) == "military"
             : stored_flight_radar_settings.traffic_mode == FLIGHT_RADAR_TRAFFIC_MILITARY_ONLY;
+    const std::string flight_radar_feeder_address =
+        request->hasArg("flight_radar_feeder_address")
+            ? bounded_arg_(request, "flight_radar_feeder_address", MAX_FLIGHT_RADAR_FEEDER_ADDRESS_LENGTH)
+            : fixed_string_(stored_flight_radar_settings.feeder_address);
 
     save_ui_language(selected_ui_language);
     save_time_server_enabled(time_server_enabled);
     save_manual_time_enabled(manual_time_valid);
     if (wifi_enabled)
       save_weather_enabled(weather_enabled);
-    save_flight_radar_settings(flight_radar_enabled, flight_radar_range_km, flight_radar_military_only);
+    save_flight_radar_settings(flight_radar_enabled, flight_radar_range_km, flight_radar_military_only,
+                               flight_radar_feeder_address);
     save_home_assistant_discovery_enabled(ha_discovery_enabled);
     save_unit_system(request->hasArg("units") && request->arg("units") == "imperial" ? UNIT_SYSTEM_IMPERIAL
                                                                                        : UNIT_SYSTEM_METRIC);

--- a/includes/airdot/setup/setup_settings.h
+++ b/includes/airdot/setup/setup_settings.h
@@ -94,6 +94,7 @@ static constexpr size_t MAX_MQTT_BROKER_LENGTH = 64;
 static constexpr size_t MAX_MQTT_USERNAME_LENGTH = 64;
 static constexpr size_t MAX_MQTT_PASSWORD_LENGTH = 64;
 static constexpr size_t MAX_MQTT_TOPIC_PREFIX_LENGTH = 64;
+static constexpr size_t MAX_FLIGHT_RADAR_FEEDER_ADDRESS_LENGTH = 96;
 static constexpr size_t MAX_SETUP_NETWORK_OPTIONS = 32;
 
 struct NetworkOption {
@@ -354,6 +355,7 @@ struct FlightRadarSettings {
   uint8_t range_km{FLIGHT_RADAR_RANGE_DEFAULT_KM};
   uint8_t traffic_mode{FLIGHT_RADAR_TRAFFIC_ALL};
   uint8_t reserved[5]{};
+  char feeder_address[MAX_FLIGHT_RADAR_FEEDER_ADDRESS_LENGTH + 1]{};
 };
 
 struct StoredNetworkOption {
@@ -783,6 +785,31 @@ inline uint8_t normalize_flight_radar_range_km(int value) {
   return static_cast<uint8_t>(FLIGHT_RADAR_RANGE_MIN_KM + steps * FLIGHT_RADAR_RANGE_STEP_KM);
 }
 
+// Keeps host[:port][/path]; strips a leading http(s):// scheme and trailing
+// slashes so the client can append /data/aircraft.json directly.
+inline std::string sanitize_flight_radar_feeder_address_(const std::string &value) {
+  std::string address = trim_copy_(value);
+  const auto scheme_pos = address.find("://");
+  if (scheme_pos != std::string::npos)
+    address = address.substr(scheme_pos + 3);
+
+  std::string sanitized;
+  sanitized.reserve(address.size());
+  for (char c : address) {
+    const bool allowed = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+                         c == '.' || c == '-' || c == '_' || c == ':' || c == '/' || c == '[' || c == ']';
+    if (allowed)
+      sanitized += c;
+  }
+  while (!sanitized.empty() && (sanitized.back() == '/' || sanitized.back() == '.'))
+    sanitized.pop_back();
+  while (!sanitized.empty() && sanitized.front() == '/')
+    sanitized.erase(sanitized.begin());
+  if (sanitized.size() > MAX_FLIGHT_RADAR_FEEDER_ADDRESS_LENGTH)
+    sanitized.resize(MAX_FLIGHT_RADAR_FEEDER_ADDRESS_LENGTH);
+  return sanitized;
+}
+
 inline FlightRadarSettings default_flight_radar_settings_() {
   FlightRadarSettings settings{};
   settings.enabled = 1;
@@ -798,6 +825,9 @@ inline void normalize_flight_radar_settings_(FlightRadarSettings &settings) {
       settings.traffic_mode == FLIGHT_RADAR_TRAFFIC_MILITARY_ONLY
           ? FLIGHT_RADAR_TRAFFIC_MILITARY_ONLY
           : FLIGHT_RADAR_TRAFFIC_ALL;
+  settings.feeder_address[MAX_FLIGHT_RADAR_FEEDER_ADDRESS_LENGTH] = '\0';
+  copy_limited_c_string_(settings.feeder_address, sizeof(settings.feeder_address),
+                         sanitize_flight_radar_feeder_address_(fixed_string_(settings.feeder_address)));
 }
 
 inline int16_t normalize_sen66_temperature_offset_centi_c_(int value) {
@@ -1211,12 +1241,23 @@ inline bool load_flight_radar_military_only() {
   return load_flight_radar_settings().traffic_mode == FLIGHT_RADAR_TRAFFIC_MILITARY_ONLY;
 }
 
-inline void save_flight_radar_settings(bool enabled, uint8_t range_km, bool military_only) {
+inline std::string load_flight_radar_feeder_address() {
+  return fixed_string_(load_flight_radar_settings().feeder_address);
+}
+
+inline bool flight_radar_feeder_configured() {
+  return !load_flight_radar_feeder_address().empty();
+}
+
+inline void save_flight_radar_settings(bool enabled, uint8_t range_km, bool military_only,
+                                       const std::string &feeder_address) {
   auto &cache = flight_radar_pref_();
   FlightRadarSettings value{};
   value.enabled = enabled ? 1 : 0;
   value.range_km = range_km;
   value.traffic_mode = military_only ? FLIGHT_RADAR_TRAFFIC_MILITARY_ONLY : FLIGHT_RADAR_TRAFFIC_ALL;
+  copy_limited_c_string_(value.feeder_address, sizeof(value.feeder_address),
+                         sanitize_flight_radar_feeder_address_(feeder_address));
   normalize_flight_radar_settings_(value);
 
   cache.value = value;

--- a/packages/features/flight_radar.yaml
+++ b/packages/features/flight_radar.yaml
@@ -34,16 +34,18 @@ script:
 
                 const uint8_t range_km = AirDot::onboarding::load_flight_radar_range_km();
                 const bool military_only = AirDot::onboarding::load_flight_radar_military_only();
+                const std::string feeder_address = AirDot::onboarding::load_flight_radar_feeder_address();
                 float exact_latitude = 0.0f;
                 float exact_longitude = 0.0f;
                 if (AirDot::onboarding::load_exact_location(exact_latitude, exact_longitude)) {
-                  AirDot::flight_radar::start_airplanes_live_request(
-                      exact_latitude, exact_longitude, range_km, military_only);
+                  AirDot::flight_radar::start_flight_radar_request(
+                      feeder_address.c_str(), exact_latitude, exact_longitude, range_km, military_only);
                 } else if (id(outdoor_location_valid)) {
-                  AirDot::flight_radar::start_airplanes_live_request(
-                      id(outdoor_latitude), id(outdoor_longitude), range_km, military_only);
+                  AirDot::flight_radar::start_flight_radar_request(
+                      feeder_address.c_str(), id(outdoor_latitude), id(outdoor_longitude), range_km, military_only);
                 } else {
-                  AirDot::flight_radar::start_airplanes_live_for_current_location_request(range_km, military_only);
+                  AirDot::flight_radar::start_flight_radar_for_current_location_request(
+                      feeder_address.c_str(), range_km, military_only);
                 }
                 id(flight_radar_next_request_ms) =
                     now + AirDot::flight_radar::FLIGHT_RADAR_REQUEST_INTERVAL_MS;
@@ -57,7 +59,7 @@ interval:
               if (!id(flight_radar_page)->is_showing())
                 return false;
               AirDot::flight_radar::Snapshot snapshot;
-              return AirDot::flight_radar::consume_airplanes_live_result(snapshot) != 0;
+              return AirDot::flight_radar::consume_flight_radar_result(snapshot) != 0;
           then:
             - script.execute: ui_refresh_flight_radar_page
   - interval: 1s

--- a/scripts/generate_i18n.py
+++ b/scripts/generate_i18n.py
@@ -158,6 +158,8 @@ SETUP_PAGE_KEYS = (
     "flight_radar_note",
     "flight_radar_enabled_title",
     "flight_radar_enabled_description",
+    "flight_radar_feeder_label",
+    "flight_radar_feeder_placeholder",
     "flight_radar_range_label",
     "flight_radar_traffic_label",
     "flight_radar_traffic_all_label",


### PR DESCRIPTION
The flight radar now fetches aircraft.json from a user-configured local feeder (tar1090, readsb or dump1090-fa) over plain HTTP instead of polling api.airplanes.live over TLS every 5 seconds. Adds a feeder address field to the setup portal, caches the IP-geolocation lookup, and updates translations and docs.